### PR TITLE
Initial commit to Support the Extreme Platform for atrium-onos 16A - master

### DIFF
--- a/apps/routing/src/main/java/org/onosproject/routing/impl/ControlPlaneRedirectManager.java
+++ b/apps/routing/src/main/java/org/onosproject/routing/impl/ControlPlaneRedirectManager.java
@@ -206,10 +206,8 @@ public class ControlPlaneRedirectManager {
             // ARP from router
             fromSelector = DefaultTrafficSelector.builder()
                     .matchInPort(controlPlanePort)
-                    .matchEthSrc(intf.mac())
                     .matchVlanId(intf.vlan())
                     .matchEthType(EthType.EtherType.ARP.ethType().toShort())
-                    .matchArpSpa(ip.ipAddress().getIp4Address())
                     .build();
 
             flowObjectiveService.forward(deviceId,

--- a/tools/test/cells/atrium_router
+++ b/tools/test/cells/atrium_router
@@ -1,0 +1,9 @@
+export ONOS_NIC=127.0.0.*
+export OC1="127.0.0.1"
+export OCN="127.0.0.1"
+export OCI="${OC1}"
+ 
+export ONOS_APPS=drivers,openflow,vrouter,proxyarp
+ 
+export ONOS_USER=admin
+export ONOS_GROUP=admin


### PR DESCRIPTION
The Extreme Platform does not support ArpSpa OF match field in the "Arp from Router" section of ControlPlaneRedirectManager.java.  Instead, this was switched to just match on Arp, vlan id, and Ingress Port. With this change, ARPs from peers remote/quagga can now successfully be sent to the onos controller

The Extreme Platform is a hybrid switch that uses the OF flow "drop all" on all ports by default. Using the new Arp match criteria above, the ONOS ProxyArp feature needs to be run at ONOS startup in order to resolve BGP neighbor hosts as well as Quagga hosts for successful BGP peering
